### PR TITLE
Update slope position when entering slope 2.

### DIFF
--- a/js/scripts/zone_loaders/mountain_zone_loaders.js
+++ b/js/scripts/zone_loaders/mountain_zone_loaders.js
@@ -160,7 +160,7 @@ const loadMountainSlope2 = () => {
         ));
         if ((LAST_ZONE && LAST_ZONE.equals(Zone.getZones().mountain.slope1) || LAST_ZONE === null)) { // Coming down the mounatin.
             // Set spawn point on the right.
-            const blockPos = new Vector(ZONE.MIN_BLOCK.x + 67, 45);
+            const blockPos = new Vector(ZONE.MIN_BLOCK.x + 1, 87);
             CHAD.pos = Vector.blockToWorldSpace(blockPos);
         } else {
             const blockPos = new Vector(ZONE.MAX_BLOCK.x - 2, 20);


### PR DESCRIPTION
I also updated the references that play music in the END zone. It should be in this PR but I'm not seeing the file changes.

Hmu if there are issues with transferring to any zone that plays `END_`... music, it's likely a reference that needs to be updated if it some how is still here.